### PR TITLE
fix  google.golang.org/grpc/naming: module google.golang.org/grpc@lat…

### DIFF
--- a/build
+++ b/build
@@ -11,6 +11,15 @@ gen_version
 
 echo "Building metad ..."
 mkdir -p bin
+
+go mod init
+
+# fix  google.golang.org/grpc/naming: module google.golang.org/grpc@latest found (v1.37.0), but does not contain package google.golang.org/grpc/naming
+# https://github.com/yunify/metad/issues/24
+go mod edit -replace google.golang.org/grpc@latest=google.golang.org/grpc@v1.26.0
+
+go mod tidy
+ 
 go build -o $OUTPUT .
 
 revert_version


### PR DESCRIPTION
…est found (v1.37.0), but does not contain package google.golang.org/grpc/naming

```
go: finding module for package google.golang.org/grpc/naming
github.com/yunify/metad/backends/etcdv3 imports
        github.com/coreos/etcd/clientv3 tested by
        github.com/coreos/etcd/clientv3.test imports
        github.com/coreos/etcd/integration imports
        github.com/coreos/etcd/proxy/grpcproxy imports
        google.golang.org/grpc/naming: module google.golang.org/grpc@latest found (v1.37.0), but does not contain package google.golang.org/grpc/naming

```